### PR TITLE
ci: фиксы тестов, специфичных для чистого Linux-runner'а

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,14 @@ jobs:
           COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.COMPOSER_GITHUB_TOKEN || github.token }}"}}'
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      # Каталоги, которые приложение пишет в рантайме, но которых нет в чистом
+      # checkout (web/scans/* и runtime/* gitignored). Без web/scans/thumbs
+      # Imagick падает на генерации превью (Scans::prepThumb -> WriteBlob Failed).
+      - name: Prepare writable runtime dirs
+        run: |
+          mkdir -p web/scans/thumbs runtime/swagger-temp tests/_output tests/log
+          chmod -R 777 web/scans runtime tests/_output tests/log
+
       # Схема тестовой БД: грузим демо-дамп проекта (acceptance/rest при старте
       # пересоздают БД из него самостоятельно, unit'у нужна готовая схема).
       - name: Load test DB schema
@@ -83,6 +91,17 @@ jobs:
 
       - name: REST tests
         run: php vendor/bin/codecept run rest
+
+      # Артефакты codeception (.fail.html/.fail.json с трейсами) — чтобы разбирать
+      # падения без перепрогона. Загружаем всегда, даже при упавших тестах.
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeception-logs
+          path: tests/log/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # ---------------------------------------------------------------------------
   # СБОРКА DOCKER-ОБРАЗА (порт build-app из .gitlab-ci.yml)

--- a/controllers/SoftController.php
+++ b/controllers/SoftController.php
@@ -237,6 +237,14 @@ class SoftController extends ArmsBaseController
 		}
 		
 		$vendor=\app\models\Manufacturers::findOne($manufacturer);
+
+		// LLM-провайдер может быть не сконфигурирован (нет ключей OpenAI/GigaChat) —
+		// например в CI. Тогда отдаём ошибку в JSON с HTTP 200, а не падаем 500
+		// при создании LlmClient (см. контракт в testGenerateDescription).
+		if (!LlmClient::available()) {
+			return ['error' => 'LLM-провайдеры недоступны'];
+		}
+
 		$generator = new LlmClient();
 		$result = $generator->generateSoftwareDescription($vendor->name.' '.$name);
 		

--- a/swagger/processors/GenerateModelSchemaProcessor.php
+++ b/swagger/processors/GenerateModelSchemaProcessor.php
@@ -33,7 +33,11 @@ class GenerateModelSchemaProcessor
 	public function __invoke(Analysis $analysis): void
 	{
 	
-		$classes=array_merge($this->apiModels(),$this->apiModels('Schedules'));
+		// Имя модуля строго в нижнем регистре: реальный каталог modules/schedules и
+		// namespace app\modules\schedules\models. На Linux (регистрозависимая ФС)
+		// 'Schedules' дало бы несуществующий путь/namespace -> схема Schedules(read)
+		// не сгенерировалась бы и api-json упал бы в 500 на нерезолвящемся $ref.
+		$classes=array_merge($this->apiModels(),$this->apiModels('schedules'));
 
 		foreach ($classes as $modelClass) {
 			$model = new $modelClass();


### PR DESCRIPTION
На GitHub-runner'е (Ubuntu, регистрозависимая ФС, нет локальных артефактов разработчика) acceptance падал в 5 местах, которых не было на Windows. Причины и фиксы:

- swagger/GenerateModelSchemaProcessor: apiModels('Schedules') ->
  'schedules'. Реальный каталог modules/schedules и namespace
  app\modules\schedules\models — строчными. На Linux 'Schedules' давал
  несуществующий путь, схема Schedules(read) не генерировалась, и
  site/api-json падал в 500 на нерезолвящемся $ref у SchedulesController.

- SoftController::actionGenerateDescription: при отсутствии LLM-провайдера (нет ключей в CI) возвращаем JSON-ошибку с HTTP 200 вместо падения 500 в конструкторе LlmClient — как и описано в контракте testGenerateDescription.

- workflow: создаём web/scans/thumbs и runtime/swagger-temp (gitignored, в чистом checkout их нет) — иначе Imagick падает на генерации превью (Scans::prepThumb -> WriteBlob Failed) на places/create и techs/view.

- workflow: грузим tests/log как артефакт (always) для разбора падений.