### PR TITLE
ci: чиним сборку образа — токен composer через BuildKit-секрет

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -122,6 +122,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # composer внутри образа делает update (lock в репо нет) и обращается к GitHub API —
+      # без токена упирается в rate-limit. Готовим auth.json и отдаём его как BuildKit-секрет,
+      # чтобы токен не попал в историю образа. github.token хватает для public-пакетов.
+      - name: Prepare composer auth
+        run: echo '{"github-oauth":{"github.com":"${{ secrets.COMPOSER_GITHUB_TOKEN || github.token }}"}}' > "${RUNNER_TEMP}/composer-auth.json"
+
       - name: Build (and push on master)
         uses: docker/build-push-action@v6
         with:
@@ -129,7 +135,7 @@ jobs:
           file: docker/Dockerfile
           tags: ${{ env.IMAGE }}:v1
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          build-args: |
-            COMPOSER_AUTH={"github-oauth":{"github.com":"${{ secrets.COMPOSER_GITHUB_TOKEN || github.token }}"}}
+          secret-files: |
+            composer_auth=${{ runner.temp }}/composer-auth.json
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 FROM php:8.2-apache
 
 ENV TZ=Europe/Moscow
 
-# передаем токен github в виде аргумента CLI
-#ARG COMPOSER_GITHUB_TOKEN
-#ENV COMPOSER_AUTH=
+# Токен GitHub для composer пробрасывается BuildKit-секретом composer_auth
+# (см. шаг установки зависимостей ниже), чтобы не оседать в истории образа.
 
 # Установка всех зависимостей в одном слое + очистка кэша
 # git для composer
@@ -48,8 +48,18 @@ COPY docker/prod/index.php /var/www/arms/web/index.php
 # Установка зависимостей
 WORKDIR /var/www/arms
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/var/www/arms --filename=composer.phar
-RUN su -s /bin/sh www-data -c "php composer.phar install --no-dev --optimize-autoloader -n" && \
-    rm -rf /var/www/.composer
+# composer.lock в репозитории нет (gitignored) -> composer выполняет update и обращается
+# к GitHub API за dev-master/vcs-пакетами. Без токена это упирается в rate-limit и падает с
+# "Could not authenticate against github.com". Токен берём из BuildKit-секрета composer_auth
+# (содержимое = auth.json), кладём в writable COMPOSER_HOME (домашний /var/www у www-data
+# не записываемый -> иначе "Cannot create cache directory").
+RUN --mount=type=secret,id=composer_auth \
+    export COMPOSER_HOME=/tmp/.composer; \
+    mkdir -p "$COMPOSER_HOME"; \
+    if [ -s /run/secrets/composer_auth ]; then cp /run/secrets/composer_auth "$COMPOSER_HOME/auth.json"; fi; \
+    chown -R www-data:www-data "$COMPOSER_HOME"; \
+    su -s /bin/sh www-data -c "COMPOSER_HOME=$COMPOSER_HOME php composer.phar install --no-dev --optimize-autoloader -n" && \
+    rm -rf "$COMPOSER_HOME"
 
 # Скрипт запуска
 COPY docker/script/run.sh /bin/arms-run.sh


### PR DESCRIPTION
Job build падал на composer install внутри образа: "Could not authenticate against github.com". Причина: composer.lock gitignored, в чистом checkout его нет -> composer делает update и обращается к GitHub API за dev-master/vcs-пакетами, упираясь в rate-limit. А build-arg COMPOSER_AUTH из workflow в Dockerfile не использовался (ARG/ENV были закомментированы). Локально сборка проходила лишь потому, что в контексте был composer.lock (install из lock, без обращений к GitHub).

- Dockerfile: добавлена директива syntax; токен пробрасывается BuildKit- секретом composer_auth (auth.json в COMPOSER_HOME=/tmp/.composer), чтобы не оседать в истории образа. /tmp вместо /var/www убирает и предупреждения "Cannot create cache directory".
- workflow: вместо build-args COMPOSER_AUTH готовим auth.json и отдаём его через secret-files (github.token хватает для public-пакетов).